### PR TITLE
Enhance dark mode toggle style

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,18 +113,19 @@ const menuEl = document.getElementById("menu");
 const themeBtn = document.getElementById("toggle-theme");
 const romanBtn = document.getElementById("toggle-roman");
 const timeSelect = document.getElementById("time-format");
-const colorThemeSelect = document.getElementById("color-theme");
+const colorCircles = document.querySelectorAll(".color-circle");
 
 // ---- APPLY SAVED SETTINGS ----
 document.body.classList.add(`theme-${colorTheme}`);
 menuEl.classList.add(`theme-${colorTheme}`);
 document.body.classList.toggle("dark", darkMode);
 menuEl.classList.toggle("dark", darkMode);
-themeBtn.textContent = darkMode ? "☀️ اجالا" : "🌙 اندھیرا";
+themeBtn.textContent = darkMode ? "☀️" : "🌙";
 romanBtn.textContent = showRoman ? "Hide Roman Urdu" : "Show Roman Urdu";
 romanEl.style.display = showRoman ? "block" : "none";
 timeSelect.value = timeFormat;
-colorThemeSelect.value = colorTheme;
+const selectedCircle = document.querySelector(`.color-circle[data-theme="${colorTheme}"]`);
+if (selectedCircle) selectedCircle.classList.add("selected");
 
 // ---- FUNCTIONS ----
 function updateThemeColors() {
@@ -228,7 +229,7 @@ themeBtn.addEventListener("click", () => {
   darkMode = !darkMode;
   localStorage.setItem("darkMode", darkMode);
   updateThemeColors();
-  themeBtn.textContent = darkMode ? "☀️ اجالا" : "🌙 اندھیرا";
+  themeBtn.textContent = darkMode ? "☀️" : "🌙";
 });
 
 romanBtn.onclick = () => {
@@ -253,14 +254,22 @@ window.addEventListener("resize", () => {
   adjustFontSize(quoteContainer, urduEl, romanEl, metaDiv);
 });
 
-// ---- COLOR THEME DROPDOWN ----
-colorThemeSelect.addEventListener("change", (e) => {
+// ---- COLOR THEME CIRCLES ----
+function applyColorTheme(theme) {
   document.body.classList.remove(`theme-${colorTheme}`);
   menuEl.classList.remove(`theme-${colorTheme}`);
-  colorTheme = e.target.value;
+  colorTheme = theme;
   document.body.classList.add(`theme-${colorTheme}`);
   menuEl.classList.add(`theme-${colorTheme}`);
   localStorage.setItem("colorTheme", colorTheme);
+}
+
+colorCircles.forEach((circle) => {
+  circle.addEventListener("click", () => {
+    colorCircles.forEach((c) => c.classList.remove("selected"));
+    circle.classList.add("selected");
+    applyColorTheme(circle.dataset.theme);
+  });
 });
 
 function adjustFontSize(quoteContainer, urduEl, romanEl, metaEl) {

--- a/index.html
+++ b/index.html
@@ -21,13 +21,13 @@
   <div class="menu-top">
   <a href="https://github.com/umair-latif/urdulitclock" target="_blank" class="menu-link">🌐GitHub</a>
   <div class="menu-right">
-    <select id="color-theme">
-      <option value="default">B&W سیاہ و سفید</option>
-      <option value="blue">Ocean نیلگوں</option>
-      <option value="maroon">Rose گلابی</option>
-      <option value="green">Emerald زمرد</option>
-    </select>
-    <button id="toggle-theme">🌙 اندھیرا</button>
+    <div class="color-options">
+      <span class="color-circle theme-default" data-theme="default" title="B&W \u0633\u06cc\u0627\u06c1 \u0648 \u0633\u0641\u06cc\u062f"></span>
+      <span class="color-circle theme-blue" data-theme="blue" title="Ocean \u0646\u06cc\u0644\u06af\u0648\u06ba"></span>
+      <span class="color-circle theme-maroon" data-theme="maroon" title="Rose \u06af\u0644\u0627\u0628\u06cc"></span>
+      <span class="color-circle theme-green" data-theme="green" title="Emerald \u0632\u0645\u0631\u062f"></span>
+    </div>
+      <button id="toggle-theme" class="theme-toggle" title="Toggle dark mode">🌙</button>
     <button id="toggle-roman">Hide Roman</button>
     <select id="time-format">
       <option value="24H">24 گھنٹے</option>

--- a/styles.css
+++ b/styles.css
@@ -106,7 +106,8 @@ body.dark .highlighted { color: #f9f9f9; }
   padding: 5px 10px;
 }
 body.dark .menu {
-  background: rgba(0,0,0,0.5);
+  /* lighter glassy shade for dark mode menu */
+  background: rgba(40, 40, 40, 0.6);
   border-top: 1px solid rgba(255,255,255,0.1);
 }
 
@@ -124,6 +125,50 @@ body.dark .menu {
   flex-direction: row-reverse;
   gap: 8px;
   margin-right: 5px;
+}
+
+/* Color theme circles */
+.color-options {
+  display: flex;
+  gap: 6px;
+}
+
+.color-circle {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+.color-circle:hover {
+  transform: scale(1.1);
+}
+.color-circle.theme-default { background: #000; }
+.color-circle.theme-blue { background: #4b6eff; }
+.color-circle.theme-maroon { background: #b03060; }
+.color-circle.theme-green { background: #1e8f5a; }
+.color-circle.selected {
+  border-color: #222; /* visible on light menu */
+}
+body.dark .color-circle.selected {
+  border-color: #fff; /* visible on dark menu */
+}
+
+/* Round button for dark/light toggle */
+.menu button.theme-toggle {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  padding: 0;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #222;
+}
+body.dark .menu button.theme-toggle {
+  border-color: #fff;
 }
 
 /* GitHub link minimal */


### PR DESCRIPTION
## Summary
- redesign light/dark mode switch as a round icon button
- ensure icon updates based on current theme
- style new toggle to match color-circle controls
- lighten menu background in dark mode for a modern glassy look

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6889d55df5fc832691808e12508a4ec6