### PR TITLE
Fix highlight error for missing transliteration

### DIFF
--- a/app.js
+++ b/app.js
@@ -172,7 +172,8 @@ function findQuote(hour, slot) {
 
 // ---- HIGHLIGHT FUNCTION ----
 function highlightText(text, highlight) {
-  if (!highlight || !text) return text;
+  if (!text) return "";          // gracefully handle missing fields
+  if (!highlight) return text;
   const regex = new RegExp(`(${highlight})`, "gi");
   return text.replace(regex, `<span class="highlighted">$1</span>`);
 }
@@ -189,7 +190,7 @@ function updateClock() {
 
   // Highlight fields
   const urduHighlighted = highlightText(quote.urdu, quote.highlight).replace(/\(ل\)/g, "<br>");
-  const romanHighlighted = highlightText(quote.transliteration, quote.highlight).replace(/\(ل\)/g, "<br>");
+  const romanHighlighted = highlightText(quote.transliteration || "", quote.highlight).replace(/\(ل\)/g, "<br>");
 
   // Render text
   // Replace (ل) with <br> before splitting lines


### PR DESCRIPTION
## Summary
- ensure `highlightText` doesn't throw when text is missing
- pass a fallback value when calling `highlightText` for transliteration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889d34e20d483269a09f7feda5ad6cc