### PR TITLE
Clean redundant CSS

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -38,42 +38,9 @@ body.theme-maroon.dark { background: #3a0d20; color: #ffd8e4; }
 body.theme-green { background: #f1fff7; color: #0e3f2e; }
 body.theme-green.dark { background: #0c2b1f; color: #ccffee; }
 
-/* === Clock Layout === */
-.clock {
-  text-align: center;
-  margin: auto;
-  width: 95%;
-  max-width: 1200px;
-  padding: 10px;
-}
 
-/* Time display – bigger on large screens */
-.time {
-  font-size: clamp(2rem, 7vw, 5rem);
-  font-weight: bold;
-  margin-bottom: 2vh;
-}
 
-/* Urdu quotes */
-.urdu {
-  font-size: clamp(1.5rem, 5vw, 3.5rem);
-  line-height: 2;
-  font-family: 'Noto Nastaliq Urdu', serif;
-  direction: rtl;
-  color: inherit;
-  word-break: break-word;
-  padding: 0 1vw;
-}
 
-/* Roman transliteration */
-.roman {
-  font-size: clamp(1.2rem, 3.5vw, 2rem);
-  font-style: italic;
-  margin-top: 2vh;
-  line-height: 1.8;
-  color: inherit;
-  padding: 0 4vw;
-}
 
 /* Highlighted text (bold, darker) */
 .highlighted {
@@ -82,13 +49,6 @@ body.theme-green.dark { background: #0c2b1f; color: #ccffee; }
 }
 body.dark .highlighted { color: #f9f9f9; }
 
-/* Metadata (source/book info) */
-.meta-info {
-  margin-top: 2vh;
-  font-size: clamp(1rem, 2.5vw, 1.6rem);
-  opacity: 0.9;
-  padding: 0 4vw;
-}
 .font-naskh { font-family: 'Noto Naskh Arabic', serif; direction: rtl; }
 
 /* === Modern Minimal Text-Based Menu === */


### PR DESCRIPTION
## Summary
- remove outdated style rules for `.clock`, `.time`, `.urdu`, `.roman` and `.meta-info`
- keep `.highlighted` rules and rely on later declarations for layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a05d50b0883269c0491d0199bddc6